### PR TITLE
Revert "Create codecov.yml"

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,0 @@
-fixes:
-  - "controller/library/Library::src/main/java"


### PR DESCRIPTION
Reverts OmicronProject/BakeoutController#16

@stevepeak, thanks for your help. After comparing my project with the codecov example implementation, I understand the issue is coming from a namespace error. I'm going to go ahead and revert this PR, fix my namespace, and try sending in another report.
